### PR TITLE
DDA-000: BackgroundDiory Heading as draggable

### DIFF
--- a/src/react/components/diories/BackgroundDiory.js
+++ b/src/react/components/diories/BackgroundDiory.js
@@ -30,17 +30,15 @@ const BackgroundDiory = ({ diory, gradient, gradientRgba, onClick, children, ...
         />
       )}
       {video && <BackgroundVideo video={video} zIndex={-1} position="fixed" {...videoStyle} />}
-      {text && (
-        <Heading
-          color={image ? 'white' : 'rgb(102, 120, 138)'}
-          fontWeight="bold"
-          width="100%"
-          {...textStyle}
-          onClick={(event) => onClick({ diory, event })}
-        >
-          {text}
-        </Heading>
-      )}
+      <Heading
+        color={image ? 'white' : 'rgb(102, 120, 138)'}
+        fontWeight="bold"
+        width="100%"
+        {...textStyle}
+        onClick={(event) => onClick({ diory, event })}
+      >
+        {text || '`'}
+      </Heading>
       {children}
     </Pane>
   )

--- a/src/react/components/diories/BackgroundDiory.js
+++ b/src/react/components/diories/BackgroundDiory.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Pane, Heading } from 'evergreen-ui'
+import { useDrag } from 'react-dnd'
 import BackgroundVideo from './BackgroundVideo'
 
 import Image from './Image'
@@ -8,6 +9,14 @@ import Image from './Image'
 const BackgroundDiory = ({ diory, gradient, gradientRgba, onClick, children, ...props }) => {
   const { id, text, image, video, style: dioryStyle = {} } = diory
   const { text: textStyle, image: imageStyle, video: videoStyle, ...style } = dioryStyle
+
+  const [, drag] = useDrag({
+    item: {
+      id: diory.id,
+      type: 'DIORY',
+    },
+  })
+
   return (
     <Pane
       id={id}
@@ -31,6 +40,7 @@ const BackgroundDiory = ({ diory, gradient, gradientRgba, onClick, children, ...
       )}
       {video && <BackgroundVideo video={video} zIndex={-1} position="fixed" {...videoStyle} />}
       <Heading
+        ref={drag}
         color={image ? 'white' : 'rgb(102, 120, 138)'}
         fontWeight="bold"
         width="100%"


### PR DESCRIPTION
Diory in focus needs to have same kind of "action area" as linked diories. "Action area" is used by update, delete and hand tools and if it's not visible any of those can't be used for the diory in focus.

Changes:
* Show <Heading /> always in BackgroundDiory (as a small white dot)
* Convert <Heading /> as draggable to get it to hand
