### PR TITLE
DDA-000: Reduce the MAXIMUM_SUBFOLDER_DEPTH 

### DIFF
--- a/electron/channels/compare-and-merge-diographs.js
+++ b/electron/channels/compare-and-merge-diographs.js
@@ -1,6 +1,6 @@
 const { isEmpty } = require('../lib/utils')
 
-const MAXIMUM_SUBFOLDER_DEPTH = 15
+const MAXIMUM_SUBFOLDER_DEPTH = 8
 
 // Returns diograph with rootId
 exports.compareAndMergeDiographs = function compareAndMergeDiographs(


### PR DESCRIPTION
With my current Diory content Update folder doesn't succeed without this fix.
This improves the performance as it doesn't have to recurse unnecessary deep when resolving bidirectional links.
But it also decreases the maximum subfolder depth that the diograph folder structure can have (although 8 should be still enough for kind of "normal folder structures"...)

Apparently this Update folder logic needs a rewrite at some time as it's very unperformant with lots of bidirectional links and larger content (uses unnecessary a lot of memory). But it might also require a change to our diograph.json format...

But didn't have time nor ideas yet. So hopefully this quick fix is enough by now.