### PR TITLE
DDA-118: Add schemas to diograph

### DIFF
--- a/electron/generators/diory-generator.integration.spec.js
+++ b/electron/generators/diory-generator.integration.spec.js
@@ -45,11 +45,25 @@ describe('diograph-generator', () => {
 
       await act()
 
-      expect(Object.keys(generatedDiory)).toEqual(['id', 'text', 'video', 'created', 'modified'])
+      // TODO: Remove video attribute as now we have diory.data.contentUrl
+      expect(Object.keys(generatedDiory)).toEqual([
+        'id',
+        'text',
+        'video',
+        'created',
+        'modified',
+        'data',
+      ])
       expect(generatedDiory.text).toEqual('some-video.mp4')
-      expect(generatedDiory.video.toString()).toEqual(
+      // TODO: Remove video attribute as now we have diory.data.contentUrl
+      expect(generatedDiory.video).toEqual(
         `file://${process.env.INIT_CWD}/electron/readers/example-folder/some-video.mp4`
       )
+      expect(generatedDiory.data).toEqual({
+        '@context': 'https://schema.org',
+        '@type': 'VideoObject',
+        contentUrl: `file://${process.env.INIT_CWD}/electron/readers/example-folder/some-video.mp4`,
+      })
     })
 
     it('generates diory from audio file', async () => {

--- a/electron/generators/diory-generator.integration.spec.js
+++ b/electron/generators/diory-generator.integration.spec.js
@@ -24,13 +24,20 @@ describe('diograph-generator', () => {
         'longitude',
         'created',
         'modified',
+        'data',
       ])
       expect(generatedDiory.date).toEqual('2008-11-01T21:15:11.000Z')
-      expect(generatedDiory.image.toString()).toEqual(
-        `file://${process.env.INIT_CWD}/electron/readers/example-folder/some-image.jpg`
-      )
+      const imageContentUrl = `file://${process.env.INIT_CWD}/electron/readers/example-folder/some-image.jpg`
+      expect(generatedDiory.image).toEqual(imageContentUrl)
       expect(generatedDiory.latitude).toEqual(43.464455)
       expect(generatedDiory.longitude).toEqual(11.881478333333334)
+      expect(generatedDiory.data).toEqual({
+        '@context': 'https://schema.org',
+        '@type': 'ImageObject',
+        contentUrl: imageContentUrl,
+        width: 640,
+        height: 480,
+      })
     })
 
     it('generates diory from video file', async () => {

--- a/electron/generators/diory-generator.integration.spec.js
+++ b/electron/generators/diory-generator.integration.spec.js
@@ -27,7 +27,7 @@ describe('diograph-generator', () => {
         'data',
       ])
       expect(generatedDiory.date).toEqual('2008-11-01T21:15:11.000Z')
-      const imageContentUrl = `file://${process.env.INIT_CWD}/electron/readers/example-folder/some-image.jpg`
+      const imageContentUrl = `${process.env.INIT_CWD}/electron/readers/example-folder/some-image.jpg`
       expect(generatedDiory.image).toEqual(imageContentUrl)
       expect(generatedDiory.latitude).toEqual(43.464455)
       expect(generatedDiory.longitude).toEqual(11.881478333333334)
@@ -57,12 +57,12 @@ describe('diograph-generator', () => {
       expect(generatedDiory.text).toEqual('some-video.mp4')
       // TODO: Remove video attribute as now we have diory.data.contentUrl
       expect(generatedDiory.video).toEqual(
-        `file://${process.env.INIT_CWD}/electron/readers/example-folder/some-video.mp4`
+        `${process.env.INIT_CWD}/electron/readers/example-folder/some-video.mp4`
       )
       expect(generatedDiory.data).toEqual({
         '@context': 'https://schema.org',
         '@type': 'VideoObject',
-        contentUrl: `file://${process.env.INIT_CWD}/electron/readers/example-folder/some-video.mp4`,
+        contentUrl: `${process.env.INIT_CWD}/electron/readers/example-folder/some-video.mp4`,
       })
     })
 

--- a/electron/generators/diory-generator.integration.spec.js
+++ b/electron/generators/diory-generator.integration.spec.js
@@ -71,8 +71,13 @@ describe('diograph-generator', () => {
 
       await act()
 
-      expect(Object.keys(generatedDiory)).toEqual(['id', 'text', 'created', 'modified'])
+      expect(Object.keys(generatedDiory)).toEqual(['id', 'text', 'created', 'modified', 'data'])
       expect(generatedDiory.text).toEqual('some-music')
+      expect(generatedDiory.data).toEqual({
+        '@context': 'https://schema.org',
+        '@type': 'AudioObject',
+        contentUrl: `${process.env.INIT_CWD}/electron/readers/example-folder/some-music.mp3`,
+      })
     })
 
     it('generates diory from document file', async () => {
@@ -80,8 +85,13 @@ describe('diograph-generator', () => {
 
       await act()
 
-      expect(Object.keys(generatedDiory)).toEqual(['id', 'text', 'created', 'modified'])
+      expect(Object.keys(generatedDiory)).toEqual(['id', 'text', 'created', 'modified', 'data'])
       expect(generatedDiory.text).toEqual('some-document')
+      expect(generatedDiory.data).toEqual({
+        '@context': 'https://schema.org',
+        '@type': 'MediaObject',
+        contentUrl: `${process.env.INIT_CWD}/electron/readers/example-folder/some-document.pdf`,
+      })
     })
   })
 })

--- a/electron/generators/diory-generator.js
+++ b/electron/generators/diory-generator.js
@@ -29,7 +29,7 @@ async function readFileData(type, filePath) {
   }
 }
 
-function generateDiory({ text, date, image, video, latitude, longitude, created, modified }) {
+function generateDiory({ text, date, image, video, latitude, longitude, created, modified, data }) {
   return {
     id: uuid(),
     ...(text && { text }),
@@ -40,6 +40,7 @@ function generateDiory({ text, date, image, video, latitude, longitude, created,
     ...(longitude && { longitude }),
     ...(created && { created }),
     ...(modified && { modified }),
+    ...(data && { data }),
   }
 }
 

--- a/electron/generators/diory-generator.js
+++ b/electron/generators/diory-generator.js
@@ -20,9 +20,22 @@ async function readFileData(type, filePath) {
         ...readVideo(filePath),
       }
     case 'audio':
+      return {
+        ...fileData,
+        data: {
+          '@context': 'https://schema.org',
+          '@type': 'AudioObject',
+          contentUrl: filePath,
+        },
+      }
     case 'text':
       return {
         ...fileData,
+        data: {
+          '@context': 'https://schema.org',
+          '@type': 'MediaObject',
+          contentUrl: filePath,
+        },
       }
     default:
       return fileData || {}

--- a/electron/readers/image-reader.js
+++ b/electron/readers/image-reader.js
@@ -1,5 +1,4 @@
 const { readFileSync } = require('fs')
-const { pathToFileURL } = require('url')
 const { load } = require('exifreader')
 
 function readExifTags(imagePath = '') {
@@ -43,11 +42,11 @@ function getLongitude({ GPSLongitude = {} }) {
   return longitude && { longitude }
 }
 
-function generateSchema(tags, imageContentUrl) {
+function generateSchema(tags, imagePath) {
   return {
     '@context': 'https://schema.org',
     '@type': 'ImageObject',
-    contentUrl: imageContentUrl,
+    contentUrl: imagePath,
     height: tags && tags['Image Height'] && tags['Image Height'].value,
     width: tags && tags['Image Width'] && tags['Image Width'].value,
   }
@@ -59,15 +58,14 @@ exports.readImage = async function readImage(imagePath) {
   }
   try {
     const tags = readExifTags(imagePath)
-    const imageContentUrl = pathToFileURL(imagePath).toString()
     return {
-      image: imageContentUrl,
+      image: imagePath,
       ...getDate(tags),
       ...getLatitude(tags),
       ...getLongitude(tags),
       ...getCreated(tags),
       data: {
-        ...generateSchema(tags, imageContentUrl),
+        ...generateSchema(tags, imagePath),
       },
     }
   } catch (error) {

--- a/electron/readers/image-reader.js
+++ b/electron/readers/image-reader.js
@@ -43,18 +43,32 @@ function getLongitude({ GPSLongitude = {} }) {
   return longitude && { longitude }
 }
 
+function generateSchema(tags, imageContentUrl) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ImageObject',
+    contentUrl: imageContentUrl,
+    height: tags && tags['Image Height'] && tags['Image Height'].value,
+    width: tags && tags['Image Width'] && tags['Image Width'].value,
+  }
+}
+
 exports.readImage = async function readImage(imagePath) {
   if (!imagePath) {
     return
   }
   try {
     const tags = readExifTags(imagePath)
+    const imageContentUrl = pathToFileURL(imagePath).toString()
     return {
-      image: pathToFileURL(imagePath),
+      image: imageContentUrl,
       ...getDate(tags),
       ...getLatitude(tags),
       ...getLongitude(tags),
       ...getCreated(tags),
+      data: {
+        ...generateSchema(tags, imageContentUrl),
+      },
     }
   } catch (error) {
     console.info(`Error reading image ${imagePath}: ${error}`)

--- a/electron/readers/video-reader.js
+++ b/electron/readers/video-reader.js
@@ -1,6 +1,14 @@
 const { basename } = require('path')
 const { pathToFileURL } = require('url')
 
+function generateSchema(videoPath) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'VideoObject',
+    contentUrl: pathToFileURL(videoPath).toString(),
+  }
+}
+
 exports.readVideo = function readVideo(videoPath) {
   if (!videoPath) {
     return
@@ -9,11 +17,11 @@ exports.readVideo = function readVideo(videoPath) {
   try {
     return {
       text: basename(videoPath),
-      video: pathToFileURL(videoPath),
-      // ...getDate(tags),
-      // ...getLatitude(tags),
-      // ...getLongitude(tags),
-      // ...getCreated(tags),
+      // TODO: Remove video attribute as now we have diory.data.contentUrl
+      video: pathToFileURL(videoPath).toString(),
+      data: {
+        ...generateSchema(videoPath),
+      },
     }
   } catch (error) {
     console.info(`Error reading video ${videoPath}: ${error}`)

--- a/electron/readers/video-reader.js
+++ b/electron/readers/video-reader.js
@@ -1,11 +1,10 @@
 const { basename } = require('path')
-const { pathToFileURL } = require('url')
 
 function generateSchema(videoPath) {
   return {
     '@context': 'https://schema.org',
     '@type': 'VideoObject',
-    contentUrl: pathToFileURL(videoPath).toString(),
+    contentUrl: videoPath,
   }
 }
 
@@ -18,7 +17,7 @@ exports.readVideo = function readVideo(videoPath) {
     return {
       text: basename(videoPath),
       // TODO: Remove video attribute as now we have diory.data.contentUrl
-      video: pathToFileURL(videoPath).toString(),
+      video: videoPath,
       data: {
         ...generateSchema(videoPath),
       },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "evergreen-ui": "5.1.2",
+    "file-url": "^4.0.0",
     "husky": "^4.3.8",
     "jest-electron": "^0.1.11",
     "jsdoc": "^3.6.6",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,11 @@
       "@babel/plugin-transform-runtime"
     ]
   },
+  "jest": {
+    "transformIgnorePatterns": [
+      "node_modules/(?!(file-url)/)"
+    ]
+  },
   "prettier": {
     "tabWidth": 2,
     "semi": false,

--- a/src/react/components/Room.js
+++ b/src/react/components/Room.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
+import fileUrl from 'file-url'
 
 const Room = ({ diory: { id, image, text, ...diory }, onClick }) => (
   <Box
@@ -19,7 +20,9 @@ const Room = ({ diory: { id, image, text, ...diory }, onClick }) => (
       alignSelf="center"
       onClick={onClick}
       aria-controls={`panel-${id}`}
-      backgroundImage={`linear-gradient(rgba(0, 0, 0, 0.1),rgba(0, 0, 0, 0.1)), url(${image})`}
+      backgroundImage={`linear-gradient(rgba(0, 0, 0, 0.1),rgba(0, 0, 0, 0.1)), url(${
+        image && image.match(/^http/) ? image : fileUrl(image.toString())
+      })`}
       backgroundRepeat="no-repeat"
       backgroundSize="cover"
       backgroundColor="pink"

--- a/src/react/components/Room.js
+++ b/src/react/components/Room.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Box from 'ui-box'
-import fileUrl from 'file-url'
+import { getImageUrl } from '../utils'
 
 const Room = ({ diory: { id, image, text, ...diory }, onClick }) => (
   <Box
@@ -20,9 +20,9 @@ const Room = ({ diory: { id, image, text, ...diory }, onClick }) => (
       alignSelf="center"
       onClick={onClick}
       aria-controls={`panel-${id}`}
-      backgroundImage={`linear-gradient(rgba(0, 0, 0, 0.1),rgba(0, 0, 0, 0.1)), url(${
-        image && image.match(/^http/) ? image : fileUrl(image.toString())
-      })`}
+      backgroundImage={`linear-gradient(rgba(0, 0, 0, 0.1),rgba(0, 0, 0, 0.1)), url(${getImageUrl(
+        image
+      )})`}
       backgroundRepeat="no-repeat"
       backgroundSize="cover"
       backgroundColor="pink"

--- a/src/react/components/diories/Image.js
+++ b/src/react/components/diories/Image.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Box from 'ui-box'
 import PropTypes from 'prop-types'
+import fileUrl from 'file-url'
 
 const defaultStyle = {
   position: 'absolute',
@@ -15,8 +16,10 @@ const defaultStyle = {
 
 const getBackgroundImage = (image, gradient, gradientRgba = '255, 255, 255, 0.5') =>
   gradient
-    ? `linear-gradient(rgba(${gradientRgba}),rgba(${gradientRgba})), url("${image}")`
-    : `url("${image}")`
+    ? `linear-gradient(rgba(${gradientRgba}),rgba(${gradientRgba})), url("${
+        image && image.match(/^http/) ? image : fileUrl(image.toString())
+      }")`
+    : `url("${image && image.match(/^http/) ? image : fileUrl(image.toString())}")`
 
 const Image = ({ image, gradient, gradientRgba, ...props }) => (
   <Box

--- a/src/react/components/diories/Image.js
+++ b/src/react/components/diories/Image.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Box from 'ui-box'
 import PropTypes from 'prop-types'
-import fileUrl from 'file-url'
+import { getImageUrl } from '../../utils'
 
 const defaultStyle = {
   position: 'absolute',
@@ -16,10 +16,8 @@ const defaultStyle = {
 
 const getBackgroundImage = (image, gradient, gradientRgba = '255, 255, 255, 0.5') =>
   gradient
-    ? `linear-gradient(rgba(${gradientRgba}),rgba(${gradientRgba})), url("${
-        image && image.match(/^http/) ? image : fileUrl(image.toString())
-      }")`
-    : `url("${image && image.match(/^http/) ? image : fileUrl(image.toString())}")`
+    ? `linear-gradient(rgba(${gradientRgba}),rgba(${gradientRgba})), url("${getImageUrl(image)}")`
+    : `url("${getImageUrl(image)}")`
 
 const Image = ({ image, gradient, gradientRgba, ...props }) => (
   <Box

--- a/src/react/features/lenses/utils/popup/createDioryPopup.js
+++ b/src/react/features/lenses/utils/popup/createDioryPopup.js
@@ -1,5 +1,5 @@
 import L from 'leaflet'
-import fileUrl from 'file-url'
+import { getImageUrl } from '../../../../utils'
 
 const colors = ['#5bc0eb', '#fcd600', '#9bc53d', '#e55934', '#fa7921']
 const getRandom = (array) => array[Math.floor(Math.random() * array.length)]
@@ -10,7 +10,7 @@ const getPopupStyle = ({ image }) =>
     'min-width: 400px',
     'min-height: 200px',
     `background-color: ${getRandom(colors)}`,
-    `background-image: url('${image && image.match(/^http/) ? image : fileUrl(image.toString())}')`,
+    `background-image: url('${getImageUrl(image)}')`,
     'background-size: cover',
     'background-position: center',
     'background-repeat: no-repeat',

--- a/src/react/features/lenses/utils/popup/createDioryPopup.js
+++ b/src/react/features/lenses/utils/popup/createDioryPopup.js
@@ -1,4 +1,5 @@
 import L from 'leaflet'
+import fileUrl from 'file-url'
 
 const colors = ['#5bc0eb', '#fcd600', '#9bc53d', '#e55934', '#fa7921']
 const getRandom = (array) => array[Math.floor(Math.random() * array.length)]
@@ -9,7 +10,7 @@ const getPopupStyle = ({ image }) =>
     'min-width: 400px',
     'min-height: 200px',
     `background-color: ${getRandom(colors)}`,
-    `background-image: url('${image}')`,
+    `background-image: url('${image && image.match(/^http/) ? image : fileUrl(image.toString())}')`,
     'background-size: cover',
     'background-position: center',
     'background-repeat: no-repeat',

--- a/src/react/features/tools/update/updateTool.feature
+++ b/src/react/features/tools/update/updateTool.feature
@@ -48,15 +48,15 @@ Feature: Update tool
 
   # Image
   Scenario: Update image
-    When I add '/test-image.png' to image field
+    When I add 'http://localhost:3300/test-image.png' to image field
     And I click Done button
     And I select tools button
     And I select update button
     And I take 'Diory 11' in focus
-    Then I see '/test-image.png' in image field
+    Then I see 'http://localhost:3300/test-image.png' in image field
 
   Scenario: Update image changes background image
-    When I add '/test-image.png' to image field
+    When I add 'http://localhost:3300/test-image.png' to image field
     And I click Done button
     Then 'diory11' has 'linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)), url("http://localhost:3300/test-image.png")' as 'background-image'
 

--- a/src/react/utils/getImageUrl.js
+++ b/src/react/utils/getImageUrl.js
@@ -1,0 +1,16 @@
+import fileUrl from 'file-url'
+
+export const getImageUrl = (imageUrl) => {
+  // Images from internet
+  if (/^http(s)?:\/\//.exec(imageUrl)) {
+    return imageUrl
+  }
+
+  // Development content
+  if (/^development-content-room/.exec(imageUrl)) {
+    return `http://localhost:3300/${imageUrl}`
+  }
+
+  // Convert absolute path to file:// url
+  return imageUrl && fileUrl(imageUrl.toString())
+}

--- a/src/react/utils/index.js
+++ b/src/react/utils/index.js
@@ -1,1 +1,2 @@
 export { debounce } from './debounce'
+export { getImageUrl } from './getImageUrl'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8578,6 +8578,11 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+file-url@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/file-url/-/file-url-4.0.0.tgz#6fe05262d3187da70bc69889091932b6bc7df270"
+  integrity sha512-vRCdScQ6j3Ku6Kd7W1kZk9c++5SqD6Xz5Jotrjr/nkY714M14RFHy/AAVA2WQvpsqVAVgTbDrYyBpU205F0cLw==
+
 filelist@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.2.tgz#80202f21462d4d1c2e214119b1807c1bc0380e5b"


### PR DESCRIPTION
* Write schema for each diory generated from file (in diory.data attribute)
* Use only absolute urls in diograph format (no fileUrls starting with file:// anymore in diograph.json)
* getImageUrl() helper created to fix frontend after change from fileUrls to absolute urls
  * Used in three places in frontend (Room.js, Image.js and createDioryPopup.js)
  * Add file-url package to convert absolute paths to file urls in frontend
  * Special handling for http-urls and our development-content

NOTE: This is BREAKING CHANGE: all the existing diograph.json files won't work after this.