### PR TITLE
DDA-103: Delete link to self & don't inactivate delete tool after deleting link

### DIFF
--- a/electron/spec/testcafe-e2e-2.test.js
+++ b/electron/spec/testcafe-e2e-2.test.js
@@ -22,6 +22,7 @@ test('select new diograph folder (without diograph.json) and delete it', async (
     .click('[data-testid="delete-button"]')
     .click(someFolderDiory)
     .click(deleteButton)
+    .click('[data-testid="tools-button"]') // Close tool bar
     .wait(1000) // Wait for SAVE_ROOM to complete and possibly raise anerror
     .click('[data-testid="home"]')
     .click('[data-testid="tools-button"]')

--- a/src/react/client/mockResponses/GET_ROOM.json
+++ b/src/react/client/mockResponses/GET_ROOM.json
@@ -62,7 +62,12 @@
     },
     "diory11": {
       "id": "diory11",
-      "text": "Diory 11"
+      "text": "Diory 11",
+      "links": {
+        "link11-to-self": {
+          "id": "diory11"
+        }
+      }
     },
     "diory12": {
       "id": "diory12",

--- a/src/react/features/tools/delete/DeleteView.js
+++ b/src/react/features/tools/delete/DeleteView.js
@@ -31,11 +31,11 @@ const DeleteView = ({ diory, diorys, onDone, onCancel }) => (
           <b>Links</b>
         </div>
         {Object.values(diorys).map((deletedLink) => (
-          <div key={deletedLink.fromDiory.id}>
+          <div key={deletedLink.fromDiory && deletedLink.fromDiory.id}>
             &quot;
-            {deletedLink.fromDiory.text || deletedLink.fromDiory.id}
+            {deletedLink.fromDiory && (deletedLink.fromDiory.text || deletedLink.fromDiory.id)}
             &quot; -&gt; &quot;
-            {deletedLink.toDiory.text || deletedLink.toDiory.id}
+            {deletedLink.toDiory && (deletedLink.toDiory.text || deletedLink.toDiory.id)}
             &quot;
           </div>
         ))}

--- a/src/react/features/tools/delete/deleteTool.feature
+++ b/src/react/features/tools/delete/deleteTool.feature
@@ -19,8 +19,6 @@ Feature: Delete tool
     And I see 'Diory 11' in view
     And 'diory14' diory not in the store
     And 'link14' link not in the store
-    # FIXME: This is just to verify the step definition
-    And 'link11' link is in the store
 
   Scenario: Link to diory in view is deleted (not the diory!)
     When I select delete button
@@ -35,6 +33,8 @@ Feature: Delete tool
     And I select delete button
     And I take 'Diory 11' in focus
     And I click Delete button
+    # Diory 11 is in focus and 'Diory 11' is shown as heading
+    # although link to 'Diory 11' is deleted from view
     Then I see 'Diory 11' in view
     And 'link11-to-self' link not in the store
     And 'link11' link is in the store
@@ -46,17 +46,20 @@ Feature: Delete tool
     And I click Cancel button
     Then I see 'Diory 11' in view
 
-  # Scenario: Diory is deleted from search
-    # When I select delete button
-    # And I take 'Diory 11' in focus
-    # And I click Delete button
-    # And I type 'Diory 11' in search bar
-    # Then I do not see 'Diory 11' in view
-
   Scenario: Delete diory is deactivated
     When I select delete button
     And I select 'delete-button--active'
     Then I see tools button
+
+  Scenario: Multiple diories are deleted from view
+    When I select delete button
+    And I take 'Diory 11' in focus
+    And I click Delete button
+    And I take 'Diory 12' in focus
+    And I click Delete button
+    Then I do not see 'Diory 11' in view
+    And I do not see 'Diory 12' in view
+    But I see 'Diory 14' in view
 
 
 

--- a/src/react/features/tools/delete/deleteTool.feature
+++ b/src/react/features/tools/delete/deleteTool.feature
@@ -30,6 +30,16 @@ Feature: Delete tool
     And 'link11' link not in the store
     And 'diory11' diory is in the store
 
+  Scenario: Link to self is deleted
+    When I take 'Diory 11' in focus
+    And I select delete button
+    And I take 'Diory 11' in focus
+    And I click Delete button
+    Then I see 'Diory 11' in view
+    And 'link11-to-self' link not in the store
+    And 'link11' link is in the store
+    And 'diory11' diory is in the store
+
   Scenario: Deleting diory is cancelled
     When I select delete button
     And I take 'Diory 11' in focus
@@ -39,7 +49,7 @@ Feature: Delete tool
   # Scenario: Diory is deleted from search
     # When I select delete button
     # And I take 'Diory 11' in focus
-    # And I click Yes button
+    # And I click Delete button
     # And I type 'Diory 11' in search bar
     # Then I do not see 'Diory 11' in view
 

--- a/src/react/features/tools/delete/useDeleteView.js
+++ b/src/react/features/tools/delete/useDeleteView.js
@@ -25,9 +25,17 @@ const reverseLinkedDiories = (focusDiory, diograph) =>
 const composeDeletedLinks = (focusDiory, linkDiory, diograph) =>
   linkedDiories(focusDiory, diograph).concat(reverseLinkedDiories(focusDiory, diograph))
 
-const isFocusDeleted = (focusDiory, linkDiory) =>
-  // TODO: Check if it has link to itself and if has => return false
-  focusDiory && linkDiory ? focusDiory.id === linkDiory.id : false
+const isFocusDeleted = (focusDiory, linkDiory) => {
+  if (focusDiory && linkDiory && focusDiory.id === linkDiory.id) {
+    if (Object.values(focusDiory.links || {}).find(({ id }) => id === focusDiory.id)) {
+      return false
+    }
+
+    return true
+  }
+
+  return false
+}
 
 export const useDeleteView = () => {
   const [{ diograph }] = useStore((state) => state.diograph)

--- a/src/react/features/tools/delete/useDeleteView.js
+++ b/src/react/features/tools/delete/useDeleteView.js
@@ -1,5 +1,4 @@
 import { useStore, useDispatch } from '../../../store'
-import { inactivateButton } from '../../buttons/actions'
 import { goBackward, setSelectedLink } from '../../navigation/actions'
 import { deleteDiory, deleteLinks } from '../../diograph/actions'
 import { useLinkDiory, useFocus } from '../../diograph/hooks'
@@ -56,7 +55,6 @@ export const useDeleteView = () => {
 
   const resetView = () => {
     dispatch(setSelectedLink())
-    dispatch(inactivateButton())
   }
 
   const deleteDioryAndLinks = () => {

--- a/src/react/features/tools/delete/useDeleteView.js
+++ b/src/react/features/tools/delete/useDeleteView.js
@@ -2,6 +2,7 @@ import { useStore, useDispatch } from '../../../store'
 import { goBackward, setSelectedLink } from '../../navigation/actions'
 import { deleteDiory, deleteLinks } from '../../diograph/actions'
 import { useLinkDiory, useFocus } from '../../diograph/hooks'
+import { inactivateButton } from '../../buttons/actions'
 
 const linkedDiories = (focusDiory, diograph) =>
   Object.values(focusDiory.links || []).map(({ id }) => ({
@@ -63,6 +64,7 @@ export const useDeleteView = () => {
     if (deletedDiory) {
       dispatch(deleteDiory(deletedDiory))
       dispatch(goBackward())
+      dispatch(inactivateButton())
     }
 
     resetView()

--- a/src/react/features/tools/delete/useDeleteView.spec.js
+++ b/src/react/features/tools/delete/useDeleteView.spec.js
@@ -41,12 +41,11 @@ describe('useDeleteView', () => {
 
       useDeleteView().onDone()
 
-      expect(mockDispatch).toHaveBeenCalledTimes(3)
+      expect(mockDispatch).toHaveBeenCalledTimes(2)
       expect(mockDispatch).toHaveBeenCalledWith(
         deleteLinks([{ fromDiory: focusDiory, toDiory: linkDiory }])
       )
       expect(mockDispatch).toHaveBeenCalledWith(setSelectedLink())
-      expect(mockDispatch).toHaveBeenCalledWith(inactivateButton())
     })
 
     it('delete focusDiory and all its links', () => {


### PR DESCRIPTION
* Delete link to self
* Don't inactivate delete tool after deleting link
  * When focus diory is deleted, delete tool is still inactivated
* Tests
  * Delete link to self + add link to self to development content (Diory 11)
  * Delete multiple diories without re-activating delete tool
* Cleanup tests