### PR TITLE
WIP: DDA-224: Open website in browser

### DIFF
--- a/src/react/features/lenses/grid/GridView.js
+++ b/src/react/features/lenses/grid/GridView.js
@@ -10,6 +10,8 @@ import DataAwareDiory from '../../../components/diories/DataAwareDiory'
 import DragDropBackground from '../../../components/DragDropBackground'
 import FullscreenBackground from '../../../components/FullscreenBackground'
 
+import { invokeChannel } from '../../../client/client'
+
 const useScrollToTopOnStoryChange = (elementRef) => {
   const { story } = useDiograph()
   useEffect(() => {
@@ -20,6 +22,7 @@ const useScrollToTopOnStoryChange = (elementRef) => {
 const GridView = ({ playRef, story, memories, page, onDrop, onClick }) => {
   const storyRef = useRef()
   const memoryRef = useRef()
+  const url = story && story.data && story.data[0].url
 
   useScrollToTopOnStoryChange(storyRef)
 
@@ -28,7 +31,13 @@ const GridView = ({ playRef, story, memories, page, onDrop, onClick }) => {
       <FullscreenBackground>
         <DataAwareDiory page={page} playRef={playRef} diory={story} />
       </FullscreenBackground>
-      <ScrollBackground>
+      <ScrollBackground
+        onClick={() => {
+          if (url) {
+            invokeChannel('openWebsiteInBrowser', url)
+          }
+        }}
+      >
         <DragDropBackground
           ref={storyRef}
           position="relative"

--- a/src/react/features/tools/open/useOpenTool.js
+++ b/src/react/features/tools/open/useOpenTool.js
@@ -7,29 +7,26 @@ import { addButtons, inactivateButton, removeButtons } from '../../buttons/butto
 
 import { invokeChannel } from '../../../client/client'
 import { buttons, OPEN_TOOL_BUTTON } from './buttons'
-import { convertToFileUrl } from '../../../utils'
 
 export const useOpenTool = () => {
   const { story } = useDiograph()
   const { active } = useSelector((state) => state.buttons)
-  const { dioryFolderLocation } = useSelector((state) => state.settings)
 
-  const contentUrl = story && story.data && story.data[0].contentUrl
+  const url = story && story.data && story.data[0].url
   const { dispatch } = useDispatchActions()
   useEffect(() => {
-    if (contentUrl) {
+    if (url) {
       dispatch(addButtons(buttons))
     } else {
       dispatch(removeButtons(buttons))
     }
-  }, [dispatch, contentUrl])
+  }, [dispatch, url])
 
   const open = active === OPEN_TOOL_BUTTON
   useEffect(() => {
     if (open) {
-      const absoluteContentUrl = convertToFileUrl(contentUrl, dioryFolderLocation)
-      invokeChannel('showItemInFolder', absoluteContentUrl)
+      invokeChannel('openWebsiteInBrowser', url)
       dispatch(inactivateButton())
     }
-  }, [dispatch, contentUrl, open, dioryFolderLocation])
+  }, [dispatch, url, open])
 }

--- a/src/react/features/tools/open/useOpenTool.js
+++ b/src/react/features/tools/open/useOpenTool.js
@@ -7,26 +7,29 @@ import { addButtons, inactivateButton, removeButtons } from '../../buttons/butto
 
 import { invokeChannel } from '../../../client/client'
 import { buttons, OPEN_TOOL_BUTTON } from './buttons'
+import { convertToFileUrl } from '../../../utils'
 
 export const useOpenTool = () => {
   const { story } = useDiograph()
   const { active } = useSelector((state) => state.buttons)
+  const { dioryFolderLocation } = useSelector((state) => state.settings)
 
-  const url = story && story.data && story.data[0].url
+  const contentUrl = story && story.data && story.data[0].contentUrl
   const { dispatch } = useDispatchActions()
   useEffect(() => {
-    if (url) {
+    if (contentUrl) {
       dispatch(addButtons(buttons))
     } else {
       dispatch(removeButtons(buttons))
     }
-  }, [dispatch, url])
+  }, [dispatch, contentUrl])
 
   const open = active === OPEN_TOOL_BUTTON
   useEffect(() => {
     if (open) {
-      invokeChannel('openWebsiteInBrowser', url)
+      const absoluteContentUrl = convertToFileUrl(contentUrl, dioryFolderLocation)
+      invokeChannel('showItemInFolder', absoluteContentUrl)
       dispatch(inactivateButton())
     }
-  }, [dispatch, url, open])
+  }, [dispatch, contentUrl, open, dioryFolderLocation])
 }


### PR DESCRIPTION
WIP:
* [ ] <ScrollBackground> in GridView.js most probably is not the right place for the click
* [ ] Update tool, memory grid clicks etc. triggers this unintentionally (because I don't know how to manage that bubbling thing...)

* Now there can be two dataobject sources for website: contentUrl from OPEN_TOOL and url from this background click!