### PR TITLE
DDA-000: Fix randomly failing map.feature test

### DIFF
--- a/src/react/features/lenses/map/map.feature
+++ b/src/react/features/lenses/map/map.feature
@@ -104,4 +104,3 @@ Feature: Map lens
     And I take 'Diory 1' in focus
     When I select map lens
     Then I see 0 focus and 0 linked markers on map
-

--- a/src/react/utils/cypress/step-definitions/map.js
+++ b/src/react/utils/cypress/step-definitions/map.js
@@ -9,11 +9,7 @@ When('I drag marker on the map', () => {
   // FIXME: Should identify the marker to be clicked
   // => now requires to have only one marker
   cy.get('img[data-testid=linked-diory-marker]').should('have.length', 2)
-  cy.get('img[data-testid=linked-diory-marker]')
-    .first()
-    .trigger('mousedown', { which: 1, force: true })
-    .trigger('mousemove', 600, 600, { force: true })
-    .trigger('mouseup')
+  cy.get('img[data-testid=linked-diory-marker]').first().move({ deltaX: 200, deltaY: 200 })
 })
 
 When('I click {string} popup on map/timeline', (dioryName) => {


### PR DESCRIPTION
- Moving diory on map in map.feature
- Use .move from @4tw/cypress-drag-drop instead of manual trigger stuff
- No guarantee but hopefully this will make it more robust