### PR TITLE
Cleanup adapters

### DIFF
--- a/electron/dcliAdapter.js
+++ b/electron/dcliAdapter.js
@@ -8,13 +8,19 @@ const ini = require('ini')
 const { validateDiosphere } = require('../src/shared/validateDiosphere')
 
 function DcliAdapter() {
-  this.loadedRoom = null
-  this.loadedDiograph = null
   this.diosphere = diosphereClass
-  this.diory = {}
   this.room = {}
   this.diograph = {}
+  this.diory = {}
+
+  // DcliAdapter specific
   this.dioryInFocus = null
+  this.loadedRoom = null
+  this.loadedDiograph = null
+
+  this.initialiseDiosphere = async (connections) => {
+    await this.selectRoom({ id: '/' })
+  }
 
   this.initialiseDiograph = async (roomObject) => {
     await this.selectRoom(roomObject)
@@ -24,44 +30,7 @@ function DcliAdapter() {
     return this.diograph
   }
 
-  this.initialiseDiosphere = async (connections) => {
-    await this.selectRoom({ id: '/' })
-  }
-
-  this.selectRoom = async (roomObject) => {
-    const roomId = roomObject.id === '/' ? 'room-1' : roomObject.id
-    this.roomConfig = this.diosphere.toObject().rooms[roomId]
-    const { address } = this.roomConfig.connections[0]
-    const clientType = this.roomConfig.connections[0].client
-
-    this.loadedRoom = await this.getRoom(address, clientType)
-    this.loadedDiograph = this.loadedRoom.diograph
-
-    validateDiograph(this.loadedDiograph.toObject())
-    this.dioryInFocus = this.loadedDiograph.getDiory({ id: '/' })
-  }
-
-  this.getRoom = async (address, clientType) => {
-    const credentials = {
-      region: 'eu-west-1',
-      credentials: {
-        accessKeyId: process.env.BUCKET_ACCESS_KEY || '',
-        secretAccessKey: process.env.BUCKET_SECRET_KEY || '',
-      },
-    }
-    return constructAndLoadRoom(address, clientType, {
-      LocalClient: {
-        clientConstructor: LocalClient2,
-      },
-      S3Client: { clientConstructor: S3Client, credentials },
-    })
-  }
-
   this.focusDiory = (dioryObject) => this.loadedDiograph.getDiory(dioryObject)
-
-  // async importDiograph(connection) {
-  //   await this.client.importDiograph([connection])
-  // },
 
   this.room.toObject = () => this.roomConfig
 
@@ -105,6 +74,36 @@ function DcliAdapter() {
 
   this.diory.toObject = () => this.dioryInFocus.toObject()
 
+  // DcliAdapter specific
+  this.selectRoom = async (roomObject) => {
+    const roomId = roomObject.id === '/' ? 'room-1' : roomObject.id
+    this.roomConfig = this.diosphere.toObject().rooms[roomId]
+    const { address } = this.roomConfig.connections[0]
+    const clientType = this.roomConfig.connections[0].client
+
+    this.loadedRoom = await this.getRoom(address, clientType)
+    this.loadedDiograph = this.loadedRoom.diograph
+
+    validateDiograph(this.loadedDiograph.toObject())
+    this.dioryInFocus = this.loadedDiograph.getDiory({ id: '/' })
+  }
+
+  this.getRoom = async (address, clientType) => {
+    const credentials = {
+      region: 'eu-west-1',
+      credentials: {
+        accessKeyId: process.env.BUCKET_ACCESS_KEY || '',
+        secretAccessKey: process.env.BUCKET_SECRET_KEY || '',
+      },
+    }
+    return constructAndLoadRoom(address, clientType, {
+      LocalClient: {
+        clientConstructor: LocalClient2,
+      },
+      S3Client: { clientConstructor: S3Client, credentials },
+    })
+  }
+
   this.getLoadedRoom = () => this.loadedRoom
 }
 
@@ -140,8 +139,6 @@ const diosphereClass = {
     const parsedDotDcli = ini.parse(dotDcliContent)
     const diosphereObject = convertDotDcliToDiosphere(parsedDotDcli)
     validateDiosphere(diosphereObject)
-    // console.log('diosphereObject', JSON.stringify(diosphereObject))
-    // console.log('diosphereObject', diosphereObject)
     return diosphereObject
   },
 }

--- a/src/react/store/dioryClientAdapter.js
+++ b/src/react/store/dioryClientAdapter.js
@@ -1,10 +1,10 @@
+import { validateDiosphere } from '../../shared/validateDiosphere'
+
 // eslint-disable-next-line import/no-unresolved
 const { validateDiograph } = require('@diograph/diograph/validator')
 
 function DioryClientAdapter(client) {
   this.dioryClient = client
-  this.dataClients = this.dioryClient.dataClients
-  this.connections = this.dioryClient.connections
   this.diosphere = this.dioryClient.diosphere
   this.room = this.dioryClient.room
   this.diograph = this.dioryClient.diograph
@@ -15,23 +15,21 @@ Object.assign(DioryClientAdapter.prototype, {
   async initialiseDiosphere(connections) {
     await this.dioryClient.initialiseDiosphere(connections)
 
-    // TODO: Diosphere validation (+ generate schema)
+    validateDiosphere(this.dioryClient.diosphere.toObject())
 
-    // sync
+    // sync internal changes from dioryClient after initialiseDiosphere
     this.room = this.dioryClient.room
-    this.connections = this.dioryClient.connections
     this.diosphere = this.dioryClient.diosphere
   },
 
   async initialiseDiograph(roomObject) {
     await this.dioryClient.initialiseDiograph(roomObject)
 
-    // TODO: Use validateDiograph from @diograph/diograph
     if (Object.keys(this.dioryClient.diograph.toObject()).length > 0) {
       validateDiograph(this.dioryClient.diograph.toObject())
     }
 
-    // sync
+    // sync internal changes from dioryClient after initialiseDiograph
     this.room = this.dioryClient.room
     this.diograph = this.dioryClient.diograph
     this.diory = this.dioryClient.diory
@@ -39,14 +37,6 @@ Object.assign(DioryClientAdapter.prototype, {
 
   focusDiory(dioryObject) {
     this.client.focusDiory(dioryObject)
-  },
-
-  // async importDiograph(connection) {
-  //   await this.client.importDiograph([connection])
-  // },
-
-  getLoadedRoom() {
-    throw new Error('Not implemented')
   },
 
   diograph: {

--- a/src/shared/validateDiosphere.js
+++ b/src/shared/validateDiosphere.js
@@ -35,6 +35,7 @@ const schema = {
               type: 'object',
               required: ['address', 'client'],
               properties: {
+                id: { type: 'string' },
                 address: { type: 'string' },
                 client: { type: 'string' },
               },


### PR DESCRIPTION
- move methods to same order
- remove methods that are not part of the interface
- add validateDiosphere to dioryClientAdapter
- indicate all the 'DcliAdapter specific methods' which implement @diory-client-js internals in DcliAdapter way (but are not part of the diory-browser-electron interface)